### PR TITLE
ValueContainerV1.cc: add a missing header

### DIFF
--- a/src/ValueContainerV1.cc
+++ b/src/ValueContainerV1.cc
@@ -1,5 +1,6 @@
 #include "ValueContainerV1.hh"
 
+#include <climits>
 #include <iostream>
 #define CHECK_FLAG(var, flag) ((var & flag) == flag)
 


### PR DESCRIPTION
CHAR_BIT can be found in climits